### PR TITLE
Support arbitrary package types

### DIFF
--- a/src/Composer/CustomDirectoryInstaller/LibraryInstaller.php
+++ b/src/Composer/CustomDirectoryInstaller/LibraryInstaller.php
@@ -37,4 +37,12 @@ class LibraryInstaller extends BaseLibraryInstaller
      */
     return parent::getInstallPath($package);
   }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function supports($packageType)
+  {
+      return true;
+  }
 }


### PR DESCRIPTION
This makes sure not only packages of `"type": "library"` are supported but any type.