### PR TITLE
Composer 2 Compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "minimum-stability": "stable",
     "require": {
         "php": ">=5.3",
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-0": {"Composer\\CustomDirectoryInstaller": "src/"}

--- a/src/Composer/CustomDirectoryInstaller/LibraryPlugin.php
+++ b/src/Composer/CustomDirectoryInstaller/LibraryPlugin.php
@@ -5,13 +5,23 @@ namespace Composer\CustomDirectoryInstaller;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
-use Composer\CustomDirectoryInstaller\LibraryInstaller;
 
 class LibraryPlugin implements PluginInterface
 {
+  private $installer;
+
   public function activate (Composer $composer, IOInterface $io)
   {
-    $installer = new LibraryInstaller($io, $composer);
-    $composer->getInstallationManager()->addInstaller($installer);
+    $this->installer = new LibraryInstaller($io, $composer);
+    $composer->getInstallationManager()->addInstaller($this->installer);
+  }
+
+  public function deactivate(Composer $composer, IOInterface $io)
+  {
+    $composer->getInstallationManager()->removeInstaller($this->installer);
+  }
+
+  public function uninstall(Composer $composer, IOInterface $io)
+  {
   }
 }

--- a/src/Composer/CustomDirectoryInstaller/PearPlugin.php
+++ b/src/Composer/CustomDirectoryInstaller/PearPlugin.php
@@ -5,13 +5,23 @@ namespace Composer\CustomDirectoryInstaller;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
-use Composer\CustomDirectoryInstaller\PearInstaller;
 
 class PearPlugin implements PluginInterface
 {
   public function activate (Composer $composer, IOInterface $io)
   {
+    if (!class_exists('Composer\Composer\Installer\PearInstaller')) {
+      return;
+    }
     $installer = new PearInstaller($io, $composer);
     $composer->getInstallationManager()->addInstaller($installer);
+  }
+
+  public function deactivate(Composer $composer, IOInterface $io)
+  {
+  }
+
+  public function uninstall(Composer $composer, IOInterface $io)
+  {
   }
 }

--- a/src/Composer/CustomDirectoryInstaller/PluginPlugin.php
+++ b/src/Composer/CustomDirectoryInstaller/PluginPlugin.php
@@ -5,13 +5,23 @@ namespace Composer\CustomDirectoryInstaller;
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Plugin\PluginInterface;
-use Composer\CustomDirectoryInstaller\PluginInstaller;
 
 class PluginPlugin implements PluginInterface
 {
+  private $installer;
+
   public function activate (Composer $composer, IOInterface $io)
   {
-    $installer = new PluginInstaller($io, $composer);
-    $composer->getInstallationManager()->addInstaller($installer);
+    $this->installer = new PluginInstaller($io, $composer);
+    $composer->getInstallationManager()->addInstaller($this->installer);
+  }
+
+  public function deactivate(Composer $composer, IOInterface $io)
+  {
+    $composer->getInstallationManager()->removeInstaller($this->installer);
+  }
+
+  public function uninstall(Composer $composer, IOInterface $io)
+  {
   }
 }


### PR DESCRIPTION
as far as i can see we only need to update the plugin classes here to support plugin api v2

but pear installer is removed in v2

see https://github.com/composer/composer/issues/8726 for more infos

edit: would be great to have a release after we reach compatibility :)