### PR TITLE
Fix PearInstaller class check

### DIFF
--- a/src/Composer/CustomDirectoryInstaller/PearPlugin.php
+++ b/src/Composer/CustomDirectoryInstaller/PearPlugin.php
@@ -10,7 +10,7 @@ class PearPlugin implements PluginInterface
 {
   public function activate (Composer $composer, IOInterface $io)
   {
-    if (!class_exists('Composer\Composer\Installer\PearInstaller')) {
+    if (!class_exists('Composer\Installer\PearInstaller')) {
       return;
     }
     $installer = new PearInstaller($io, $composer);


### PR DESCRIPTION
## Summary
- fix plugin activate logic to check correct PearInstaller class

## Testing
- `php -v` *(fails: command not found)*
- `composer --version` *(fails: command not found)*