### PR TITLE
Add PHPUnit and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: php-actions/composer@v6
+        with:
+          php_version: '8.3'
+      - run: vendor/bin/phpunit
+      - run: vendor/bin/php-cs-fixer fix --dry-run --diff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,4 @@ jobs:
         with:
           php_version: '8.3'
       - run: vendor/bin/phpunit
-      - run: vendor/bin/php-cs-fixer fix --dry-run --diff
+      - run: vendor/bin/php-cs-fixer fix src --dry-run --diff

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor/
 composer.lock
+
+.php-cs-fixer.cache

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ shell:
 	$(DOCKER) $(IMAGE) sh
 
 format:
-	$(DOCKER) $(IMAGE) vendor/bin/php-cs-fixer fix
+	$(DOCKER) $(IMAGE) vendor/bin/php-cs-fixer fix src
 
 
 build-docker-image:

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,12 @@
         }
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.75"
+        "friendsofphp/php-cs-fixer": "^3.75",
+        "phpunit/phpunit": "^10.5"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Composer\\CustomDirectoryInstaller\\Tests\\": "tests/"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,24 @@
             "email": "mina.nsami@gmail.com"
         }
     ],
+    "config": {
+        "sort-packages": true
+    },
     "minimum-stability": "stable",
+    "prefer-stable": true,
+    "version": "2.0.0",
     "require": {
         "php": ">=5.3",
         "composer-plugin-api": "^1.0 || ^2.0"
     },
     "autoload": {
         "psr-4": {
-            "Composer\\CustomDirectoryInstaller\\": "src/"
+            "Composer\\CustomDirectoryInstaller\\": "src/Composer/CustomDirectoryInstaller"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "App\\Tests\\Unit\\": "tests/Unit"
         }
     },
     "extra": {
@@ -33,10 +43,5 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.75",
         "phpunit/phpunit": "^10.5"
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Composer\\CustomDirectoryInstaller\\Tests\\": "tests/"
-        }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="PackageUtils Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Composer/CustomDirectoryInstaller/LibraryInstaller.php
+++ b/src/Composer/CustomDirectoryInstaller/LibraryInstaller.php
@@ -12,7 +12,7 @@ class LibraryInstaller extends BaseLibraryInstaller
     {
         $path = PackageUtils::getPackageInstallPath($package, $this->composer);
 
-        if(!empty($path)) {
+        if (!empty($path)) {
             return $path;
         }
 

--- a/src/Composer/CustomDirectoryInstaller/LibraryPlugin.php
+++ b/src/Composer/CustomDirectoryInstaller/LibraryPlugin.php
@@ -8,7 +8,7 @@ use Composer\Plugin\PluginInterface;
 
 class LibraryPlugin implements PluginInterface
 {
-  private $installer;
+  private LibraryInstaller $installer;
 
   public function activate (Composer $composer, IOInterface $io)
   {

--- a/src/Composer/CustomDirectoryInstaller/LibraryPlugin.php
+++ b/src/Composer/CustomDirectoryInstaller/LibraryPlugin.php
@@ -8,20 +8,20 @@ use Composer\Plugin\PluginInterface;
 
 class LibraryPlugin implements PluginInterface
 {
-  private LibraryInstaller $installer;
+    private LibraryInstaller $installer;
 
-  public function activate (Composer $composer, IOInterface $io)
-  {
-    $this->installer = new LibraryInstaller($io, $composer);
-    $composer->getInstallationManager()->addInstaller($this->installer);
-  }
+    public function activate(Composer $composer, IOInterface $io)
+    {
+        $this->installer = new LibraryInstaller($io, $composer);
+        $composer->getInstallationManager()->addInstaller($this->installer);
+    }
 
-  public function deactivate(Composer $composer, IOInterface $io)
-  {
-    $composer->getInstallationManager()->removeInstaller($this->installer);
-  }
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+        $composer->getInstallationManager()->removeInstaller($this->installer);
+    }
 
-  public function uninstall(Composer $composer, IOInterface $io)
-  {
-  }
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }

--- a/src/Composer/CustomDirectoryInstaller/PackageUtils.php
+++ b/src/Composer/CustomDirectoryInstaller/PackageUtils.php
@@ -26,15 +26,15 @@ class PackageUtils
 
         if ($composer->getPackage()) {
             $extra = $composer->getPackage()->getExtra();
-            if(!empty($extra['installer-paths'])) {
+            if (!empty($extra['installer-paths'])) {
                 $customPath = self::mapCustomInstallPaths($extra['installer-paths'], $prettyName);
-                if(false !== $customPath) {
+                if (false !== $customPath) {
                     return self::templatePath($customPath, $availableVars);
                 }
             }
         }
 
-        return NULL;
+        return null;
     }
 
     /**

--- a/src/Composer/CustomDirectoryInstaller/PearInstaller.php
+++ b/src/Composer/CustomDirectoryInstaller/PearInstaller.php
@@ -7,18 +7,18 @@ use Composer\Installer\PearInstaller as BasePearInstaller;
 
 class PearInstaller extends BasePearInstaller
 {
-  public function getInstallPath(PackageInterface $package)
-  {
-    $path = PackageUtils::getPackageInstallPath($package, $this->composer);
+    public function getInstallPath(PackageInterface $package)
+    {
+        $path = PackageUtils::getPackageInstallPath($package, $this->composer);
 
-    if(!empty($path)) {
-        return $path;
+        if (!empty($path)) {
+            return $path;
+        }
+
+        /*
+         * In case, the user didn't provide a custom path
+         * use the default one, by calling the parent::getInstallPath function
+         */
+        return parent::getInstallPath($package);
     }
-
-    /*
-     * In case, the user didn't provide a custom path
-     * use the default one, by calling the parent::getInstallPath function
-     */
-    return parent::getInstallPath($package);
-  }
 }

--- a/src/Composer/CustomDirectoryInstaller/PearPlugin.php
+++ b/src/Composer/CustomDirectoryInstaller/PearPlugin.php
@@ -8,20 +8,20 @@ use Composer\Plugin\PluginInterface;
 
 class PearPlugin implements PluginInterface
 {
-  public function activate (Composer $composer, IOInterface $io)
-  {
-    if (!class_exists('Composer\Installer\PearInstaller')) {
-      return;
+    public function activate(Composer $composer, IOInterface $io)
+    {
+        if (!class_exists('Composer\Installer\PearInstaller')) {
+            return;
+        }
+        $installer = new PearInstaller($io, $composer);
+        $composer->getInstallationManager()->addInstaller($installer);
     }
-    $installer = new PearInstaller($io, $composer);
-    $composer->getInstallationManager()->addInstaller($installer);
-  }
 
-  public function deactivate(Composer $composer, IOInterface $io)
-  {
-  }
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
 
-  public function uninstall(Composer $composer, IOInterface $io)
-  {
-  }
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }

--- a/src/Composer/CustomDirectoryInstaller/PluginInstaller.php
+++ b/src/Composer/CustomDirectoryInstaller/PluginInstaller.php
@@ -7,18 +7,18 @@ use Composer\Installer\PluginInstaller as BasePluginInstaller;
 
 class PluginInstaller extends BasePluginInstaller
 {
-  public function getInstallPath(PackageInterface $package)
-  {
-    $path = PackageUtils::getPackageInstallPath($package, $this->composer);
+    public function getInstallPath(PackageInterface $package)
+    {
+        $path = PackageUtils::getPackageInstallPath($package, $this->composer);
 
-    if(!empty($path)) {
-        return $path;
+        if (!empty($path)) {
+            return $path;
+        }
+
+        /*
+         * In case, the user didn't provide a custom path
+         * use the default one, by calling the parent::getInstallPath function
+         */
+        return parent::getInstallPath($package);
     }
-
-    /*
-     * In case, the user didn't provide a custom path
-     * use the default one, by calling the parent::getInstallPath function
-     */
-    return parent::getInstallPath($package);
-  }
 }

--- a/src/Composer/CustomDirectoryInstaller/PluginPlugin.php
+++ b/src/Composer/CustomDirectoryInstaller/PluginPlugin.php
@@ -8,20 +8,20 @@ use Composer\Plugin\PluginInterface;
 
 class PluginPlugin implements PluginInterface
 {
-  private $installer;
+    private $installer;
 
-  public function activate (Composer $composer, IOInterface $io)
-  {
-    $this->installer = new PluginInstaller($io, $composer);
-    $composer->getInstallationManager()->addInstaller($this->installer);
-  }
+    public function activate(Composer $composer, IOInterface $io)
+    {
+        $this->installer = new PluginInstaller($io, $composer);
+        $composer->getInstallationManager()->addInstaller($this->installer);
+    }
 
-  public function deactivate(Composer $composer, IOInterface $io)
-  {
-    $composer->getInstallationManager()->removeInstaller($this->installer);
-  }
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+        $composer->getInstallationManager()->removeInstaller($this->installer);
+    }
 
-  public function uninstall(Composer $composer, IOInterface $io)
-  {
-  }
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }

--- a/tests/PackageUtilsTest.php
+++ b/tests/PackageUtilsTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Composer\CustomDirectoryInstaller\Tests;
+
+use Composer\CustomDirectoryInstaller\PackageUtils;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+class PackageUtilsTest extends TestCase
+{
+    public function testTemplatePathReplacesVariables()
+    {
+        $method = new ReflectionMethod(PackageUtils::class, 'templatePath');
+        $method->setAccessible(true);
+        $result = $method->invoke(null, 'lib/{$vendor}/{$name}', ['vendor' => 'foo', 'name' => 'bar']);
+        $this->assertSame('lib/foo/bar', $result);
+    }
+
+    public function testMapCustomInstallPathsReturnsMatchingPath()
+    {
+        $method = new ReflectionMethod(PackageUtils::class, 'mapCustomInstallPaths');
+        $method->setAccessible(true);
+        $paths = [
+            'custom/one' => ['a/b'],
+            'custom/two' => ['c/d']
+        ];
+        $result = $method->invoke(null, $paths, 'a/b');
+        $this->assertSame('custom/one', $result);
+
+        $noMatch = $method->invoke(null, $paths, 'e/f');
+        $this->assertFalse($noMatch);
+    }
+}

--- a/tests/Unit/PackageUtilsTest.php
+++ b/tests/Unit/PackageUtilsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Composer\CustomDirectoryInstaller\Tests;
+namespace App\Tests\Unit;
 
 use Composer\CustomDirectoryInstaller\PackageUtils;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
## Summary
- add phpunit dev dependency and autoload-dev
- add simple PackageUtils tests
- configure GitHub Actions workflow to run phpunit and php-cs-fixer
- provide phpunit configuration

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit --version` *(fails: no such file or directory)*
- `vendor/bin/php-cs-fixer --version` *(fails: no such file or directory)*