### PR TITLE
Fix PearPlugin class check

### DIFF
--- a/src/Composer/CustomDirectoryInstaller/PearPlugin.php
+++ b/src/Composer/CustomDirectoryInstaller/PearPlugin.php
@@ -10,7 +10,7 @@ class PearPlugin implements PluginInterface
 {
   public function activate (Composer $composer, IOInterface $io)
   {
-    if (!class_exists('Composer\Composer\Installer\PearInstaller')) {
+    if (!class_exists('Composer\Installer\PearInstaller')) {
       return;
     }
     $installer = new PearInstaller($io, $composer);


### PR DESCRIPTION
## Summary
- fix PearPlugin so it checks for `Composer\Installer\PearInstaller`

## Testing
- `php -v`