### PR TITLE
fix: security hardening, precedence fix, and code quality improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,85 @@
+# CLAUDE.md
+
+## Commands
+
+All commands assume `vendor/` is installed. Use Docker via the Makefile targets if PHP is unavailable locally.
+
+```bash
+# Install dependencies
+composer install
+# or via Docker (builds image first)
+make composer-install
+
+# Run tests
+vendor/bin/phpunit
+# or via Docker (no local PHP needed)
+docker run --rm -v "$(pwd)":/app -w /app composer-custom-directory-installer vendor/bin/phpunit
+
+# Run a single test file
+vendor/bin/phpunit tests/Unit/PackageUtilsTest.php
+
+# Check code style (dry-run)
+vendor/bin/php-cs-fixer fix src --dry-run --diff --config .php-cs-fixer.dist.php
+
+# Auto-fix code style
+vendor/bin/php-cs-fixer fix src
+# or via Docker
+make format
+
+# Check code style via Docker (dry-run, CI-equivalent)
+docker run --rm -v "$(pwd)":/app -w /app composer-custom-directory-installer vendor/bin/php-cs-fixer fix src --dry-run --diff --config .php-cs-fixer.dist.php
+```
+
+CI runs `phpunit` + `php-cs-fixer` dry-run against PHP 8.1, 8.2, and 8.3.
+
+Available Makefile targets: `composer-install`, `format`, `shell`, `build-docker-image`. There is no `make test` — use the Docker run command above directly.
+
+The Docker image emits a `PHP Startup: Unable to load dynamic library 'zip'` warning on every run — this is harmless, the project doesn't use the zip extension.
+
+The Docker image must be built first (`make composer-install` does this). If `composer.json` `require-dev` changes, run `docker run --rm -v "$(pwd)":/app -w /app composer-custom-directory-installer composer update` — the lock file must include dev deps or Composer classes won't load in tests.
+
+## Architecture
+
+This is a **Composer plugin** (`type: composer-plugin`) that installs packages into custom paths instead of the default `vendor/` directory. It registers three installers — one per Composer package type — via three corresponding plugin entry points listed in `extra.class` in `composer.json`.
+
+### Plugin / Installer pairs
+
+Each pair follows the same pattern: the Plugin implements `PluginInterface`, instantiates its Installer, and registers it with Composer's `InstallationManager`. The Installer overrides `getInstallPath()` by delegating to `PackageUtils`, then falling back to the parent if no custom path is configured.
+
+| Plugin | Installer | Handles |
+|---|---|---|
+| `LibraryPlugin` | `LibraryInstaller` | `library` type (default) |
+| `PearPlugin` | `PearInstaller` | `pear-library` type (deprecated in Composer 2.x) |
+| `PluginPlugin` | `PluginInstaller` | `composer-plugin` type |
+
+### Path resolution (`PackageUtils`)
+
+All path logic lives in `PackageUtils::getPackageInstallPath()`. The flow:
+
+1. Extract `{$vendor}`, `{$name}`, `{$type}` from the package.
+2. Check if the package's own `extra.installer-name` overrides `{$name}`.
+3. Read `extra.installer-paths` from the **root** package's `composer.json`.
+4. Call `mapCustomInstallPaths()` which uses a **three-pass** approach to enforce precedence **globally across all entries** (not per-entry):
+   - Pass 1: Exact name match (`"vendor/name"`) — scans all entries first
+   - Pass 2: Type prefix match (`"type:library"`) — scans all entries
+   - Pass 3: Wildcard glob match (`"vendor/*"`) — scans all entries last
+5. Substitute `{$...}` variables with `templatePath()`.
+6. Reject resolved paths containing `..` (traversal guard) or starting with `/` or a drive letter (absolute path guard).
+
+### Namespace
+
+All source files use `Composer\CustomDirectoryInstaller\`. Tests use `App\Tests\Unit\`.
+
+### Test structure
+
+Tests live in `tests/Unit/` — one file per source class. Protected/private methods in `PackageUtils` are tested via `ReflectionMethod` (see `callProtected()` helper in `PackageUtilsTest`).
+
+## Gotchas
+
+**Precedence is global across entries, not per-entry.** An exact match in entry 2 beats a wildcard in entry 1. The three-pass algorithm in `mapCustomInstallPaths()` scans all entries for exact matches before considering type or wildcard matches in any entry.
+
+**`installer-name` affects substitution, not matching.** A package's `extra.installer-name` overrides the `{$name}` variable used in path templates, but pattern matching still uses the original `vendor/name` from `getPrettyName()`. A pattern of `"acme/foo"` will NOT match a package named `acme/bar` even if that package sets `installer-name: foo`.
+
+**`PearPlugin` is always a no-op in Composer 2.x.** `Composer\Installer\PearInstaller` was removed in Composer 2.x. `PearPlugin::activate()` checks `class_exists()` and skips registration if the class is absent, so PEAR tests are always skipped in the dev environment. `$installer` is nullable (`?PearInstaller = null`) and `deactivate()` guards against it being null.
+
+**`failOnDeprecation` is enabled in `phpunit.xml`.** The test suite fails on any PHP deprecation notice, including those from Composer internals. New code that calls deprecated Composer API methods will break CI even if logic is correct.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You can use the following variables in your `installer-paths` to build dynamic p
 Matching Strategies
 -------------------
 
-`installer-paths` supports three matching strategies, evaluated in order of precedence:
+`installer-paths` supports three matching strategies. Precedence is evaluated **globally across all entries**: all entries are first scanned for an exact name match, then for a type match, then for a wildcard match. An exact match in a later-listed entry always wins over a wildcard match in an earlier-listed entry.
 
 ### 1. Exact package name (highest precedence)
 
@@ -153,7 +153,12 @@ Complete example
 Security
 --------
 
-Resolved install paths are validated to prevent directory traversal attacks. A path resolving to a value that contains `..` will throw an `InvalidArgumentException`.
+Resolved install paths are validated against two attack vectors:
+
+- **Directory traversal** — a resolved path containing `..` throws an `InvalidArgumentException`.
+- **Absolute path injection** — a resolved path that is absolute (starting with `/` or a Windows drive letter) throws an `InvalidArgumentException`. This can occur when a package's `installer-name` is set to an absolute path value.
+
+Both checks apply after all `{$variable}` substitutions are complete.
 
 Upgrading from v1.x
 --------------------

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
-         colors="true">
+         colors="true"
+         failOnWarning="true"
+         failOnDeprecation="true">
     <testsuites>
         <testsuite name="Custom Directory Installer Test Suite">
             <directory>tests</directory>

--- a/src/Composer/CustomDirectoryInstaller/LibraryInstaller.php
+++ b/src/Composer/CustomDirectoryInstaller/LibraryInstaller.php
@@ -26,14 +26,10 @@ class LibraryInstaller extends BaseLibraryInstaller
     {
         $path = PackageUtils::getPackageInstallPath($package, $this->composer);
 
-        if (!empty($path)) {
+        if ($path !== null) {
             return $path;
         }
 
-        /*
-         * In case, the user didn't provide a custom path
-         * use the default one, by calling the parent::getInstallPath function
-         */
         return parent::getInstallPath($package);
     }
 }

--- a/src/Composer/CustomDirectoryInstaller/LibraryPlugin.php
+++ b/src/Composer/CustomDirectoryInstaller/LibraryPlugin.php
@@ -14,7 +14,7 @@ use Composer\Plugin\PluginInterface;
  */
 class LibraryPlugin implements PluginInterface
 {
-    private LibraryInstaller $installer;
+    private ?LibraryInstaller $installer = null;
 
     /**
      * Activates the plugin by registering the LibraryInstaller.
@@ -38,7 +38,9 @@ class LibraryPlugin implements PluginInterface
      */
     public function deactivate(Composer $composer, IOInterface $io): void
     {
-        $composer->getInstallationManager()->removeInstaller($this->installer);
+        if ($this->installer !== null) {
+            $composer->getInstallationManager()->removeInstaller($this->installer);
+        }
     }
 
     /**

--- a/src/Composer/CustomDirectoryInstaller/PackageUtils.php
+++ b/src/Composer/CustomDirectoryInstaller/PackageUtils.php
@@ -25,17 +25,19 @@ class PackageUtils
      *  - Package type prefix: "type:library"
      *  - Wildcard glob:       "vendor/*"
      *
+     * Precedence is enforced globally across all installer-paths entries, not per-entry.
+     *
      * Supported path variables: {$vendor}, {$name}, {$type}
      *
      * @param PackageInterface $package  The package being installed.
      * @param Composer         $composer The Composer instance (used to read root extra).
      * @return string|null The resolved install path, or null if no match found.
-     * @throws \InvalidArgumentException If the resolved path contains '..'.
+     * @throws \InvalidArgumentException If the resolved path contains '..' or is absolute.
      */
     public static function getPackageInstallPath(PackageInterface $package, Composer $composer): ?string
     {
         $prettyName = $package->getPrettyName();
-        if (strpos($prettyName, '/') !== false) {
+        if (str_contains($prettyName, '/')) {
             [$vendor, $name] = explode('/', $prettyName);
         } else {
             $vendor = '';
@@ -51,9 +53,10 @@ class PackageUtils
         }
 
         $extra = $composer->getPackage()->getExtra();
-        if (!empty($extra['installer-paths'])) {
+        if (!empty($extra['installer-paths']) && is_array($extra['installer-paths'])) {
+            $paths = array_filter($extra['installer-paths'], 'is_array');
             $customPath = self::mapCustomInstallPaths(
-                $extra['installer-paths'],
+                $paths,
                 $prettyName,
                 $package->getType()
             );
@@ -64,6 +67,15 @@ class PackageUtils
                     throw new \InvalidArgumentException(
                         sprintf(
                             "Resolved install path '%s' contains '..', which is not allowed.",
+                            $resolvedPath
+                        )
+                    );
+                }
+
+                if (str_starts_with($resolvedPath, '/') || preg_match('/^[A-Za-z]:[\\/\\\\]/', $resolvedPath)) {
+                    throw new \InvalidArgumentException(
+                        sprintf(
+                            "Resolved install path '%s' must be a relative path.",
                             $resolvedPath
                         )
                     );
@@ -87,13 +99,12 @@ class PackageUtils
      */
     protected static function templatePath(string $path, array $vars = []): string
     {
-        if (strpos($path, '{') !== false) {
-            preg_match_all('@\{\$([A-Za-z0-9_]*)\}@i', $path, $matches);
-            if (!empty($matches[1])) {
-                foreach ($matches[1] as $var) {
-                    $path = str_replace('{$' . $var . '}', $vars[$var] ?? '', $path);
-                }
-            }
+        if (str_contains($path, '{')) {
+            $path = (string) preg_replace_callback(
+                '@\{\$([A-Za-z0-9_]+)\}@',
+                static fn(array $m): string => $vars[$m[1]] ?? '',
+                $path
+            );
         }
 
         return $path;
@@ -102,7 +113,7 @@ class PackageUtils
     /**
      * Search through installer-paths config for a path matching the given package name/type.
      *
-     * Matching precedence (highest to lowest):
+     * Matching precedence (highest to lowest), enforced globally across all entries:
      *  1. Exact package name match (e.g. "vendor/name")
      *  2. Package type prefix match (e.g. "type:library")
      *  3. Wildcard glob match (e.g. "vendor/*")
@@ -114,18 +125,24 @@ class PackageUtils
      */
     protected static function mapCustomInstallPaths(array $paths, string $name, string $type = ''): string|false
     {
+        // Pass 1: exact name match (highest precedence across all entries)
         foreach ($paths as $path => $names) {
-            // 1. Exact name match
             if (in_array($name, $names)) {
                 return $path;
             }
+        }
 
-            // 2. Type-based match (e.g. "type:wordpress-plugin")
-            if (!empty($type) && in_array('type:' . $type, $names)) {
-                return $path;
+        // Pass 2: type-prefix match
+        if (!empty($type)) {
+            foreach ($paths as $path => $names) {
+                if (in_array('type:' . $type, $names)) {
+                    return $path;
+                }
             }
+        }
 
-            // 3. Wildcard glob match (e.g. "vendor/*")
+        // Pass 3: wildcard glob match (lowest precedence)
+        foreach ($paths as $path => $names) {
             foreach ($names as $pattern) {
                 if (str_contains($pattern, '*') && fnmatch($pattern, $name)) {
                     return $path;

--- a/src/Composer/CustomDirectoryInstaller/PearInstaller.php
+++ b/src/Composer/CustomDirectoryInstaller/PearInstaller.php
@@ -29,14 +29,10 @@ class PearInstaller extends BasePearInstaller
     {
         $path = PackageUtils::getPackageInstallPath($package, $this->composer);
 
-        if (!empty($path)) {
+        if ($path !== null) {
             return $path;
         }
 
-        /*
-         * In case, the user didn't provide a custom path
-         * use the default one, by calling the parent::getInstallPath function
-         */
         return parent::getInstallPath($package);
     }
 }

--- a/src/Composer/CustomDirectoryInstaller/PluginInstaller.php
+++ b/src/Composer/CustomDirectoryInstaller/PluginInstaller.php
@@ -26,14 +26,10 @@ class PluginInstaller extends BasePluginInstaller
     {
         $path = PackageUtils::getPackageInstallPath($package, $this->composer);
 
-        if (!empty($path)) {
+        if ($path !== null) {
             return $path;
         }
 
-        /*
-         * In case, the user didn't provide a custom path
-         * use the default one, by calling the parent::getInstallPath function
-         */
         return parent::getInstallPath($package);
     }
 }

--- a/src/Composer/CustomDirectoryInstaller/PluginPlugin.php
+++ b/src/Composer/CustomDirectoryInstaller/PluginPlugin.php
@@ -14,7 +14,7 @@ use Composer\Plugin\PluginInterface;
  */
 class PluginPlugin implements PluginInterface
 {
-    private PluginInstaller $installer;
+    private ?PluginInstaller $installer = null;
 
     /**
      * Activates the plugin by registering the PluginInstaller.
@@ -38,7 +38,9 @@ class PluginPlugin implements PluginInterface
      */
     public function deactivate(Composer $composer, IOInterface $io): void
     {
-        $composer->getInstallationManager()->removeInstaller($this->installer);
+        if ($this->installer !== null) {
+            $composer->getInstallationManager()->removeInstaller($this->installer);
+        }
     }
 
     /**

--- a/tests/Unit/LibraryPluginTest.php
+++ b/tests/Unit/LibraryPluginTest.php
@@ -65,6 +65,6 @@ class LibraryPluginTest extends TestCase
             $this->createMock(Composer::class),
             $this->createMock(IOInterface::class)
         );
-        $this->assertTrue(true);
+        $this->expectNotToPerformAssertions();
     }
 }

--- a/tests/Unit/PackageUtilsTest.php
+++ b/tests/Unit/PackageUtilsTest.php
@@ -142,6 +142,28 @@ class PackageUtilsTest extends TestCase
         $this->assertSame('exact-path', $result);
     }
 
+    public function testMapCustomInstallPathsExactNameWinsOverWildcardInEarlierEntry(): void
+    {
+        // Wildcard entry listed first — exact match in a later entry must still win.
+        $paths = [
+            'wildcard-path' => ['acme/*'],
+            'exact-path' => ['acme/mylib'],
+        ];
+        $result = $this->callProtected('mapCustomInstallPaths', [$paths, 'acme/mylib', '']);
+        $this->assertSame('exact-path', $result);
+    }
+
+    public function testMapCustomInstallPathsTypeMatchWinsOverWildcardInEarlierEntry(): void
+    {
+        // Wildcard entry listed first — type match in a later entry must still win.
+        $paths = [
+            'wildcard-path' => ['acme/*'],
+            'type-path' => ['type:library'],
+        ];
+        $result = $this->callProtected('mapCustomInstallPaths', [$paths, 'acme/mylib', 'library']);
+        $this->assertSame('type-path', $result);
+    }
+
     public function testMapCustomInstallPathsEmptyPathsReturnsFalse(): void
     {
         $result = $this->callProtected('mapCustomInstallPaths', [[], 'acme/mylib', '']);
@@ -234,5 +256,39 @@ class PackageUtilsTest extends TestCase
         $composer = $this->makeComposer(['installer-paths' => ['custom/{$vendor}/{$name}' => ['acme/../../etc/passwd']]]);
 
         PackageUtils::getPackageInstallPath($package, $composer);
+    }
+
+    public function testGetPackageInstallPathThrowsOnPathTraversalViaInstallerName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("contains '..'");
+
+        // installer-name override injects traversal into the resolved path
+        $package = $this->makePackage('acme/mylib', ['installer-name' => '../../etc/passwd']);
+        $composer = $this->makeComposer(['installer-paths' => ['custom/{$name}' => ['acme/mylib']]]);
+
+        PackageUtils::getPackageInstallPath($package, $composer);
+    }
+
+    public function testGetPackageInstallPathThrowsOnAbsolutePathViaInstallerName(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("must be a relative path");
+
+        // installer-name override produces an absolute resolved path with no ".."
+        $package = $this->makePackage('acme/mylib', ['installer-name' => '/etc/passwd']);
+        $composer = $this->makeComposer(['installer-paths' => ['{$name}' => ['acme/mylib']]]);
+
+        PackageUtils::getPackageInstallPath($package, $composer);
+    }
+
+    public function testGetPackageInstallPathIgnoresMalformedInstallerPathsScalarValue(): void
+    {
+        // installer-paths value is a string instead of an array — must not throw TypeError
+        $package = $this->makePackage('acme/mylib');
+        $composer = $this->makeComposer(['installer-paths' => ['custom/{$name}' => 'acme/mylib']]);
+
+        $result = PackageUtils::getPackageInstallPath($package, $composer);
+        $this->assertNull($result);
     }
 }

--- a/tests/Unit/PearPluginTest.php
+++ b/tests/Unit/PearPluginTest.php
@@ -58,6 +58,6 @@ class PearPluginTest extends TestCase
             $this->createMock(Composer::class),
             $this->createMock(IOInterface::class)
         );
-        $this->assertTrue(true);
+        $this->expectNotToPerformAssertions();
     }
 }

--- a/tests/Unit/PluginPluginTest.php
+++ b/tests/Unit/PluginPluginTest.php
@@ -65,6 +65,6 @@ class PluginPluginTest extends TestCase
             $this->createMock(Composer::class),
             $this->createMock(IOInterface::class)
         );
-        $this->assertTrue(true);
+        $this->expectNotToPerformAssertions();
     }
 }


### PR DESCRIPTION
## Summary

- **Security** — Block absolute path injection via `installer-name` (e.g. `installer-name: /etc/passwd` producing a rooted path). This is a new guard alongside the existing `..` traversal check. Both guards apply after all variable substitutions.
- **Logic bug** — `mapCustomInstallPaths()` now enforces exact → type → wildcard precedence **globally across all entries**. Previously, a wildcard in an earlier-listed entry could shadow an exact match in a later entry. Fixed with a three-pass approach.
- **Crash fix** — `$installer` in `LibraryPlugin` and `PluginPlugin` is now `?Type = null` with a null-guard in `deactivate()`, matching the already-correct `PearPlugin` pattern. Calling `deactivate()` before `activate()` no longer throws a fatal uninitialized property error.
- **Correctness** — `!empty($path)` → `$path !== null` in all three installers, matching the `?string` return type declared by `PackageUtils`.
- **Robustness** — `installer-paths` values that are scalars instead of arrays are now silently skipped (via `array_filter(..., 'is_array')`) instead of throwing a `TypeError`.
- **Code quality** — `templatePath()` simplified to a single `preg_replace_callback` pass; `strpos() !== false` replaced with `str_contains()` throughout; `assertTrue(true)` noop tests replaced with `expectNotToPerformAssertions()`; `failOnWarning`/`failOnDeprecation` added to `phpunit.xml`.
- **Docs** — README updated to document the absolute path guard and clarify that matching precedence is global across entries.

## Test Plan

- [ ] `vendor/bin/phpunit` — 40 tests, all pass (5 new tests added covering cross-entry precedence, absolute path injection, `installer-name` traversal, and malformed config)
- [ ] `vendor/bin/php-cs-fixer fix src --dry-run` — 0 violations
- [ ] CI matrix (PHP 8.1 / 8.2 / 8.3) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)