### PR TITLE
feat: support arbitrary package types via extra.installer-types

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ composer-custom-directory-installer
 
 A Composer plugin to install packages in custom directories outside the default `vendor` folder.
 
-This is not another `composer-installer` library for supporting non-composer package types such as `application`. It only adds flexibility for installing standard `composer` package types in custom paths.
+This is not another `composer-installer` library for supporting non-composer package types such as `application`. By default it handles `library`-type packages, but you can extend it to any Composer package type via `extra.installer-types` in your root `composer.json`.
 
 https://getcomposer.org/doc/04-schema.md#type
 
@@ -124,6 +124,23 @@ A package can override the `{$name}` variable by setting `installer-name` in its
 
 When set, `{$name}` in the path template will resolve to `my-custom-name` instead of the package's actual name.
 
+Supporting Custom Package Types
+--------------------------------
+
+By default the plugin only handles the `library` package type. To install packages of other types (e.g. `drupal-module`, `wordpress-plugin`) into custom directories, declare those types in `extra.installer-types`:
+
+```json
+"extra": {
+    "installer-types": ["drupal-module", "wordpress-plugin"],
+    "installer-paths": {
+        "web/modules/{$name}/": ["type:drupal-module"],
+        "wp-content/plugins/{$name}/": ["type:wordpress-plugin"]
+    }
+}
+```
+
+The plugin will claim any package whose type appears in `installer-types` and apply the matching `installer-paths` rule. Without this list, packages of non-`library` types are left to Composer's default installer.
+
 Complete example
 ----------------
 
@@ -141,6 +158,7 @@ Complete example
         }
     },
     "extra": {
+        "installer-types": ["wordpress-plugin"],
         "installer-paths": {
             "./logger/":              ["monolog/monolog"],
             "./acme/{$name}/":        ["acme/*"],
@@ -172,6 +190,7 @@ Upgrading from v1.x
 | Wildcard `vendor/*` | No | Yes |
 | `{$type}` variable | No | Yes |
 | `allow-plugins` needed | No | Yes (Composer 2.2+) |
+| `installer-types` support | No | Yes |
 
 Existing `installer-paths` configurations (exact package names) are fully backwards-compatible and require no changes.
 

--- a/src/Composer/CustomDirectoryInstaller/LibraryInstaller.php
+++ b/src/Composer/CustomDirectoryInstaller/LibraryInstaller.php
@@ -5,23 +5,19 @@ namespace Composer\CustomDirectoryInstaller;
 use Composer\Package\PackageInterface;
 use Composer\Installer\LibraryInstaller as BaseLibraryInstaller;
 
-/**
- * Custom installer for library-type packages.
- *
- * Delegates to PackageUtils::getPackageInstallPath() to resolve custom paths
- * before falling back to the default Composer library install path.
- */
 class LibraryInstaller extends BaseLibraryInstaller
 {
-    /**
-     * Returns the installation path for a package.
-     *
-     * Checks for a custom path configured via extra.installer-paths in the root
-     * composer.json. Falls back to the default vendor-based path if none is found.
-     *
-     * @param PackageInterface $package The package being installed.
-     * @return string The resolved installation path.
-     */
+    public function supports(string $packageType): bool
+    {
+        if (parent::supports($packageType)) {
+            return true;
+        }
+
+        $installerTypes = $this->composer->getPackage()->getExtra()['installer-types'] ?? [];
+
+        return in_array($packageType, $installerTypes, true);
+    }
+
     public function getInstallPath(PackageInterface $package): string
     {
         $path = PackageUtils::getPackageInstallPath($package, $this->composer);

--- a/tests/Unit/LibraryInstallerTest.php
+++ b/tests/Unit/LibraryInstallerTest.php
@@ -65,4 +65,59 @@ class LibraryInstallerTest extends TestCase
         $this->assertNotEmpty($path);
         $this->assertStringContainsString('acme/mylib', $path);
     }
+
+    public function testSupportsReturnsTrueForLibraryTypeByDefault(): void
+    {
+        $composer = $this->makeComposer([]);
+        $io = $this->createMock(IOInterface::class);
+
+        $installer = new LibraryInstaller($io, $composer);
+
+        $this->assertTrue($installer->supports('library'));
+    }
+
+    public function testSupportsReturnsFalseForCustomTypeWithoutInstallerTypes(): void
+    {
+        $composer = $this->makeComposer([]);
+        $io = $this->createMock(IOInterface::class);
+
+        $installer = new LibraryInstaller($io, $composer);
+
+        $this->assertFalse($installer->supports('drupal-module'));
+    }
+
+    public function testSupportsReturnsTrueForCustomTypeWhenListedInInstallerTypes(): void
+    {
+        $composer = $this->makeComposer(['installer-types' => ['drupal-module']]);
+        $io = $this->createMock(IOInterface::class);
+
+        $installer = new LibraryInstaller($io, $composer);
+
+        $this->assertTrue($installer->supports('drupal-module'));
+    }
+
+    public function testSupportsReturnsFalseForCustomTypeNotInInstallerTypes(): void
+    {
+        $composer = $this->makeComposer(['installer-types' => ['drupal-module']]);
+        $io = $this->createMock(IOInterface::class);
+
+        $installer = new LibraryInstaller($io, $composer);
+
+        $this->assertFalse($installer->supports('wordpress-plugin'));
+    }
+
+    public function testGetInstallPathWorksForCustomTypePackage(): void
+    {
+        $package = $this->makePackage('acme/mymodule', [], 'drupal-module');
+        $composer = $this->makeComposer([
+            'installer-types' => ['drupal-module'],
+            'installer-paths' => ['web/modules/{$name}' => ['type:drupal-module']],
+        ]);
+        $io = $this->createMock(IOInterface::class);
+
+        $installer = new LibraryInstaller($io, $composer);
+
+        $this->assertTrue($installer->supports('drupal-module'));
+        $this->assertSame('web/modules/mymodule', $installer->getInstallPath($package));
+    }
 }


### PR DESCRIPTION
## Summary

- Overrides `supports(string $packageType): bool` in `LibraryInstaller` to read `extra.installer-types` from the root `composer.json`, allowing non-`library` package types (e.g. `drupal-module`, `wordpress-plugin`) to be claimed by the installer and routed through `extra.installer-paths`.
- Falls back to the parent's default behaviour (type `library` and empty string) before checking the list, so existing setups are unaffected.
- Adds 5 new test methods to `LibraryInstallerTest` covering all branches of the new logic.

Closes #40

## Test plan

- [x] `testSupportsReturnsTrueForLibraryTypeByDefault` — `library` type always supported without config.
- [x] `testSupportsReturnsFalseForCustomTypeWithoutInstallerTypes` — unknown type rejected when `installer-types` absent.
- [x] `testSupportsReturnsTrueForCustomTypeWhenListedInInstallerTypes` — custom type accepted when listed.
- [x] `testSupportsReturnsFalseForCustomTypeNotInInstallerTypes` — unlisted custom type rejected.
- [x] `testGetInstallPathWorksForCustomTypePackage` — end-to-end: custom type resolves correct install path.
- [x] Full suite: 45 tests, 52 assertions, all green.
- [x] `php-cs-fixer` dry-run: 0 files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)