### PR TITLE
feat: support formatting flags in path placeholders ({|flags})

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,43 @@ You can use the following variables in your `installer-paths` to build dynamic p
 | `{$name}`   | The package name (or `installer-name` override) | `monolog`          |
 | `{$type}`   | The Composer package type                       | `library`          |
 
+### Path Variable Flags
+
+You can append transformation flags after a pipe (`|`) to modify how a variable is substituted:
+
+```
+{$token|flags}
+```
+
+Flags are applied **left-to-right** in the order given:
+
+| Flag | Transformation | Example input | Example output |
+|------|----------------|---------------|----------------|
+| `F`  | Capitalize first letter (`ucfirst`) | `my-package` | `My-package` |
+| `P`  | Strip hyphens/underscores and capitalize each following word | `my-package` | `myPackage` |
+| `U`  | Uppercase all characters | `my-package` | `MY-PACKAGE` |
+
+Flags can be combined. `FP` together produces **PascalCase** (capitalize first + strip separators):
+
+| Expression | Input | Output |
+|------------|-------|--------|
+| `{$name\|F}` | `my-package` | `My-package` |
+| `{$name\|P}` | `my-package` | `myPackage` |
+| `{$name\|FP}` | `my-package` | `MyPackage` |
+| `{$name\|U}` | `my-package` | `MY-PACKAGE` |
+| `{$vendor\|U}` | `acme` | `ACME` |
+
+**Example:**
+
+```json
+"installer-paths": {
+    "src/{$vendor|U}/{$name|FP}/": ["acme/my-package"],
+    "modules/{$name|FP}/":         ["type:drupal-module"]
+}
+```
+
+For a package `acme/my-package` (type `library`), this resolves to `src/ACME/MyPackage/`.
+
 ```json
 "extra": {
     "installer-paths": {
@@ -172,6 +209,7 @@ Upgrading from v1.x
 | Wildcard `vendor/*` | No | Yes |
 | `{$type}` variable | No | Yes |
 | `allow-plugins` needed | No | Yes (Composer 2.2+) |
+| Path variable flags (`\|F`, `\|P`, `\|U`) | No | Yes |
 
 Existing `installer-paths` configurations (exact package names) are fully backwards-compatible and require no changes.
 

--- a/src/Composer/CustomDirectoryInstaller/PackageUtils.php
+++ b/src/Composer/CustomDirectoryInstaller/PackageUtils.php
@@ -89,11 +89,12 @@ class PackageUtils
     }
 
     /**
-     * Replace {$var} placeholders in a path string.
+     * Replace {$var} and {$var|flags} placeholders in a path string.
      *
      * Unknown placeholders are substituted with an empty string.
+     * Optional pipe-separated flags transform the substituted value (see applyFlags()).
      *
-     * @param  string               $path The path template, e.g. "lib/{$vendor}/{$name}".
+     * @param  string               $path The path template, e.g. "lib/{$vendor}/{$name|FP}".
      * @param  array<string,string> $vars Map of variable name to replacement value.
      * @return string The path with all known placeholders substituted.
      */
@@ -101,13 +102,55 @@ class PackageUtils
     {
         if (str_contains($path, '{')) {
             $path = (string) preg_replace_callback(
-                '@\{\$([A-Za-z0-9_]+)\}@',
-                static fn(array $m): string => $vars[$m[1]] ?? '',
+                '@\{\$([A-Za-z0-9_]+)(?:\|([A-Za-z]*))?\}@',
+                static function (array $m) use ($vars): string {
+                    $value = $vars[$m[1]] ?? '';
+                    if (isset($m[2]) && $m[2] !== '') {
+                        $value = self::applyFlags($value, $m[2]);
+                    }
+
+                    return $value;
+                },
                 $path
             );
         }
 
         return $path;
+    }
+
+    /**
+     * Apply formatting flags to a string value.
+     *
+     * Flags are applied left-to-right:
+     *  F — ucfirst: capitalize first letter
+     *  P — pascal/camel: strip hyphens and underscores, capitalize each following word segment
+     *  U — strtoupper: uppercase all characters
+     *
+     * Unknown flags are silently ignored.
+     *
+     * @param  string $value The value to transform.
+     * @param  string $flags One or more flag characters (e.g. "FP", "U").
+     * @return string The transformed value.
+     */
+    protected static function applyFlags(string $value, string $flags): string
+    {
+        $len = strlen($flags);
+        for ($i = 0; $i < $len; $i++) {
+            switch ($flags[$i]) {
+                case 'F':
+                    $value = ucfirst($value);
+                    break;
+                case 'P':
+                    $parts = preg_split('/[-_]+/', $value) ?: [$value];
+                    $value = $parts[0] . implode('', array_map('ucfirst', array_slice($parts, 1)));
+                    break;
+                case 'U':
+                    $value = strtoupper($value);
+                    break;
+            }
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/Unit/PackageUtilsTest.php
+++ b/tests/Unit/PackageUtilsTest.php
@@ -87,6 +87,62 @@ class PackageUtilsTest extends TestCase
         $this->assertSame('/', $result);
     }
 
+    // templatePath() — flags
+
+    public function testTemplatePathFlagFCapitalizesFirstLetter(): void
+    {
+        $result = $this->callProtected('templatePath', ['{$name|F}', ['name' => 'my-package']]);
+        $this->assertSame('My-package', $result);
+    }
+
+    public function testTemplatePathFlagPRemovesSeparatorsAndCamelCases(): void
+    {
+        $result = $this->callProtected('templatePath', ['{$name|P}', ['name' => 'my-package']]);
+        $this->assertSame('myPackage', $result);
+    }
+
+    public function testTemplatePathFlagPRemovesUnderscores(): void
+    {
+        $result = $this->callProtected('templatePath', ['{$name|P}', ['name' => 'my_package']]);
+        $this->assertSame('myPackage', $result);
+    }
+
+    public function testTemplatePathFlagUUppercasesAll(): void
+    {
+        $result = $this->callProtected('templatePath', ['{$name|U}', ['name' => 'my-package']]);
+        $this->assertSame('MY-PACKAGE', $result);
+    }
+
+    public function testTemplatePathFlagFPProducesPascalCase(): void
+    {
+        $result = $this->callProtected('templatePath', ['{$name|FP}', ['name' => 'my-package']]);
+        $this->assertSame('MyPackage', $result);
+    }
+
+    public function testTemplatePathFlagFPOnSingleWord(): void
+    {
+        $result = $this->callProtected('templatePath', ['{$name|FP}', ['name' => 'mypackage']]);
+        $this->assertSame('Mypackage', $result);
+    }
+
+    public function testTemplatePathUnknownFlagIsIgnored(): void
+    {
+        $result = $this->callProtected('templatePath', ['{$name|X}', ['name' => 'foo']]);
+        $this->assertSame('foo', $result);
+    }
+
+    public function testTemplatePathNoFlagBehaviourUnchanged(): void
+    {
+        $result = $this->callProtected('templatePath', ['{$name}', ['name' => 'my-package']]);
+        $this->assertSame('my-package', $result);
+    }
+
+    public function testTemplatePathMixedFlagsAndPlainPlaceholders(): void
+    {
+        $result = $this->callProtected('templatePath', ['lib/{$vendor}/{$name|FP}', ['vendor' => 'acme', 'name' => 'my-lib']]);
+        $this->assertSame('lib/acme/MyLib', $result);
+    }
+
     // -----------------------------------------------------------------------
     // mapCustomInstallPaths()
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extends the `{$token}` placeholder syntax in `installer-paths` to support optional pipe-separated formatting flags: `{$token|flags}`
- Implements three flags applied left-to-right: `F` (ucfirst), `P` (camelCase — strips hyphens/underscores and capitalises each following word segment), `U` (strtoupper)
- Unknown flags are silently ignored; existing `{$token}` placeholders without flags are unaffected (regression-safe)
- Adds `applyFlags(string $value, string $flags): string` protected static method to `PackageUtils`
- Adds 9 new test methods to `PackageUtilsTest` covering all flags, combinations (FP for PascalCase), single-word edge cases, unknown flag pass-through, and a mixed placeholder regression guard

Closes #41

## Test plan

- [ ] `vendor/bin/phpunit` — all 49 tests pass (40 existing + 9 new)
- [ ] `vendor/bin/php-cs-fixer fix src --dry-run --diff` — no style violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)