### PR TITLE
docs: improve discoverability — Why section, use cases, oomphinc migration, keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ https://getcomposer.org/doc/04-schema.md#type
 >
 > Package types are used for custom installation logic. If you have a package that needs some special logic, you can define a custom type. This could be a symfony-bundle, a wordpress-plugin or a typo3-module. These types will all be specific to certain projects, and they will need to provide an installer capable of installing packages of that type.
 
+Why this plugin?
+----------------
+
+Composer has a built-in `installer-paths` key, but it only works if the package itself declares a dependency on `composer/installers` — something most packages on Packagist don't do. If you add an `installer-paths` rule for a package that doesn't opt in, Composer silently ignores it and installs the package to `vendor/` anyway.
+
+This plugin removes that constraint. It intercepts installation at the root-project level, so any package can be redirected to a custom path without requiring any changes to the package itself.
+
+In short: if you've ever added `installer-paths` and nothing happened, this plugin is the fix.
+
 Requirements
 ------------
 
@@ -204,6 +213,121 @@ Complete example
     }
 }
 ```
+
+Real-world use cases
+--------------------
+
+### WordPress with WPackagist
+
+Most WordPress plugins available via [WPackagist](https://wpackagist.org) don't require `composer/installers`, so native `installer-paths` silently fails for them. This plugin makes it work:
+
+```json
+{
+    "require": {
+        "mnsami/composer-custom-directory-installer": "^2.1",
+        "wpackagist-plugin/contact-form-7": "*",
+        "wpackagist-theme/twentytwentyfour": "*"
+    },
+    "config": {
+        "allow-plugins": {
+            "mnsami/composer-custom-directory-installer": true
+        }
+    },
+    "extra": {
+        "installer-types": ["wordpress-plugin", "wordpress-theme"],
+        "installer-paths": {
+            "wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
+            "wp-content/themes/{$name}/":  ["type:wordpress-theme"]
+        }
+    }
+}
+```
+
+### Docker / keeping vendor outside the web root
+
+Put one package (e.g. a CLI tool) in a path that's bind-mounted into a container, while everything else stays in `vendor/`:
+
+```json
+"extra": {
+    "installer-paths": {
+        "/tools/{$name}/": ["vendor/some-cli-tool"]
+    }
+}
+```
+
+### Monorepos with sibling library directories
+
+Route internal packages to their canonical location in the repo tree:
+
+```json
+"extra": {
+    "installer-types": ["company-module"],
+    "installer-paths": {
+        "../modules/{$name}/": ["type:company-module"]
+    }
+}
+```
+
+### PascalCase or namespaced paths
+
+Use [path variable flags](#path-variable-flags) to match the naming convention your framework expects:
+
+```json
+"extra": {
+    "installer-paths": {
+        "src/Modules/{$name|FP}/": ["acme/*"]
+    }
+}
+```
+
+`acme/my-module` installs to `src/Modules/MyModule/`.
+
+Migrating from oomphinc/composer-installers-extender
+------------------------------------------------------
+
+[`oomphinc/composer-installers-extender`](https://packagist.org/packages/oomphinc/composer-installers-extender) has not had a functional release since December 2021. This plugin is a maintained, drop-in alternative with a superset of its features (path variable flags, three-pass precedence, traversal guards).
+
+**Before:**
+
+```json
+"require": {
+    "composer/installers": "^2.0",
+    "oomphinc/composer-installers-extender": "^2.0"
+},
+"config": {
+    "allow-plugins": {
+        "composer/installers": true,
+        "oomphinc/composer-installers-extender": true
+    }
+},
+"extra": {
+    "installer-types": ["drupal-module"],
+    "installer-paths": {
+        "web/modules/contrib/{$name}/": ["type:drupal-module"]
+    }
+}
+```
+
+**After:**
+
+```json
+"require": {
+    "mnsami/composer-custom-directory-installer": "^2.1"
+},
+"config": {
+    "allow-plugins": {
+        "mnsami/composer-custom-directory-installer": true
+    }
+},
+"extra": {
+    "installer-types": ["drupal-module"],
+    "installer-paths": {
+        "web/modules/contrib/{$name}/": ["type:drupal-module"]
+    }
+}
+```
+
+The `extra.installer-types` and `extra.installer-paths` keys are identical — only the `require` and `allow-plugins` entries change. If you required `composer/installers` solely for path routing (not for any package's own declared dependency), you can remove it too.
 
 Security
 --------

--- a/README.md
+++ b/README.md
@@ -5,6 +5,32 @@ A Composer plugin to install packages in custom directories outside the default 
 
 This is not another `composer-installer` library for supporting non-composer package types such as `application`. By default it handles `library`-type packages, but you can extend it to any Composer package type via `extra.installer-types` in your root `composer.json`.
 
+Table of Contents
+-----------------
+
+- [Why this plugin?](#why-this-plugin)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [How to use](#how-to-use)
+- [Path Variables](#path-variables)
+  - [Path Variable Flags](#path-variable-flags)
+- [Matching Strategies](#matching-strategies)
+  - [Exact package name](#1-exact-package-name-highest-precedence)
+  - [Package type prefix](#2-package-type-prefix)
+  - [Wildcard vendor glob](#3-wildcard-vendor-glob-lowest-precedence)
+- [Custom `installer-name`](#custom-installer-name)
+- [Supporting Custom Package Types](#supporting-custom-package-types)
+- [Complete example](#complete-example)
+- [Real-world use cases](#real-world-use-cases)
+  - [WordPress with WPackagist](#wordpress-with-wpackagist)
+  - [Docker / keeping vendor outside the web root](#docker--keeping-vendor-outside-the-web-root)
+  - [Monorepos with sibling library directories](#monorepos-with-sibling-library-directories)
+  - [PascalCase or namespaced paths](#pascalcase-or-namespaced-paths)
+- [Migrating from oomphinc/composer-installers-extender](#migrating-from-oomphinccomposer-installers-extender)
+- [Security](#security)
+- [Upgrading from v1.x](#upgrading-from-v1x)
+- [Note](#note)
+
 https://getcomposer.org/doc/04-schema.md#type
 
 > The type of the package. It defaults to library.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "composer-plugin",
     "description": "A composer plugin, to help install packages of different types in custom paths.",
     "license": "MIT",
-    "keywords": ["composer", "composer-plugin", "composer-installer"],
+    "keywords": ["composer", "composer-plugin", "composer-installer", "custom-path", "installer-paths", "wordpress", "drupal", "monorepo"],
     "authors": [
         {
             "name": "Mina Nabil Sami",


### PR DESCRIPTION
## Summary

- **Why this plugin?** — new section near the top explaining that native `installer-paths` silently does nothing unless the package requires `composer/installers`, and how this plugin removes that constraint
- **Real-world use cases** — concrete examples for WordPress/WPackagist, Docker (vendor outside web root), monorepos, and PascalCase path naming
- **Migrating from oomphinc/composer-installers-extender** — step-by-step migration guide targeting the 29M-download package that has been unmaintained since December 2021; the `extra.installer-types` and `extra.installer-paths` config is identical, only `require` and `allow-plugins` change
- **Packagist keywords** — added `custom-path`, `installer-paths`, `wordpress`, `drupal`, `monorepo` for better search discoverability

## Motivation

Marketing research showed:
- 5.1M downloads but only 139 stars → large silent user base that never found the repo via search
- The package appears in zero WordPress/Composer deployment guides despite solving the #1 pain point in that space
- `oomphinc/composer-installers-extender` (29M downloads, 480 dependents) is the incumbent but effectively dead — its user base is a direct migration opportunity
- The most common developer question ("why is installer-paths not working?") is answered nowhere in the current README

## Test plan

- [ ] README renders correctly on GitHub (check headers, tables, code blocks)
- [ ] `composer.json` keywords are valid strings (no spaces, lowercase preferred)
- [ ] All existing tests still pass (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)