### PR TITLE
fix: remove persistent warning from PearPlugin in Composer 2.x

### DIFF
--- a/src/Composer/CustomDirectoryInstaller/PearPlugin.php
+++ b/src/Composer/CustomDirectoryInstaller/PearPlugin.php
@@ -19,8 +19,8 @@ class PearPlugin implements PluginInterface
     /**
      * Activates the plugin by registering the PearInstaller.
      *
-     * Logs a warning and skips registration if PearInstaller is not available
-     * (e.g. when running under Composer 2.x).
+     * Skips registration silently if PearInstaller is not available
+     * (e.g. when running under Composer 2.x, where PEAR support was removed).
      *
      * @param Composer    $composer The Composer instance.
      * @param IOInterface $io       The input/output interface.
@@ -29,8 +29,6 @@ class PearPlugin implements PluginInterface
     public function activate(Composer $composer, IOInterface $io): void
     {
         if (!class_exists('Composer\Installer\PearInstaller')) {
-            $io->writeError('<warning>PearInstaller is not available (removed in Composer 2.x); PearPlugin skipping registration.</warning>');
-
             return;
         }
         $this->installer = new PearInstaller($io, $composer);

--- a/tests/Unit/PearPluginTest.php
+++ b/tests/Unit/PearPluginTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class PearPluginTest extends TestCase
 {
-    public function testActivateSkipsRegistrationAndLogsWarningWhenPearInstallerUnavailable(): void
+    public function testActivateSkipsRegistrationSilentlyWhenPearInstallerUnavailable(): void
     {
         if (class_exists('Composer\Installer\PearInstaller')) {
             $this->markTestSkipped('BasePearInstaller is present in this environment; cannot test the skip path.');
@@ -23,9 +23,7 @@ class PearPluginTest extends TestCase
         $composer->method('getInstallationManager')->willReturn($installationManager);
 
         $io = $this->createMock(IOInterface::class);
-        $io->expects($this->once())
-            ->method('writeError')
-            ->with($this->stringContains('PearInstaller'));
+        $io->expects($this->never())->method('writeError');
 
         $plugin = new PearPlugin();
         $plugin->activate($composer, $io);


### PR DESCRIPTION
- Remove the ->writeError() call that was logging a warning every time PearPlugin::activate() was called in Composer 2.x environments
- Since PEAR support is expected to be unavailable in Composer 2.x, silent skipping is the appropriate behavior rather than warning
- Update the corresponding test to verify silent skipping without logging

Fixes #52